### PR TITLE
fix: update chunkname and no-bind rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Paris'
+    target-branch: 'develop'
+    allow:
+      - dependency-type: 'production'

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     'import',
   ],
   rules: {
-    'import/dynamic-import-chunkname': 'error',
+    'import/dynamic-import-chunkname': 'off',
     'import/export': 'error',
     'import/extensions': 'off',
     'import/newline-after-import': 'error',
@@ -91,11 +91,11 @@ module.exports = {
     'react/jsx-fragments': ['error', 'syntax'],
     'react/jsx-key': 'error',
     'react/jsx-no-bind': [
-      'error',
+      'warn',
       {
         ignoreDOMComponents: false,
         ignoreRefs: false,
-        allowArrowFunctions: false,
+        allowArrowFunctions: true,
         allowFunctions: false,
         allowBind: false,
       },


### PR DESCRIPTION
Disable the `import/dynamic-import-chunkname` rule since there is no need for it on RN.

Also tweak the `react/jsx-no-bind` rule, to not optimize prematurely.