### PR TITLE
fix: disable react in scope with new jsx transform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Paris'
+    target-branch: 'develop'
+    allow:
+      - dependency-type: 'production'

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     'import',
   ],
   rules: {
-    'import/dynamic-import-chunkname': 'error',
+    'import/dynamic-import-chunkname': 'off',
     'import/export': 'error',
     'import/extensions': 'off',
     'import/newline-after-import': 'error',
@@ -91,11 +91,11 @@ module.exports = {
     'react/jsx-fragments': ['error', 'syntax'],
     'react/jsx-key': 'error',
     'react/jsx-no-bind': [
-      'error',
+      'warn',
       {
         ignoreDOMComponents: false,
         ignoreRefs: false,
-        allowArrowFunctions: false,
+        allowArrowFunctions: true,
         allowFunctions: false,
         allowBind: false,
       },

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = {
     'react/no-unused-class-component-methods': 'error',
     'react/no-unused-state': 'error',
     'react/no-will-update-set-state': 'error',
-    'react/react-in-jsx-scope': 'error',
+    'react/react-in-jsx-scope': 'off',
     'react/require-render-return': 'error',
     'react/self-closing-comp': 'error',
     'react/state-in-constructor': ['error', 'never'],


### PR DESCRIPTION
No need to have `React` in scope with the new `JSX` transform